### PR TITLE
Throw abort in before_save callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bundler_stubs/
 /tmp
 /coverage
 .rspec
+.ruby-gemset

--- a/lib/active_service/model.rb
+++ b/lib/active_service/model.rb
@@ -63,7 +63,12 @@ module ActiveService
       # Configure ActiveModel callbacks
       extend ActiveModel::Callbacks
       define_model_callbacks :save, :create, :update, :destroy
-      before_save { !destroyed? && valid? }
+
+      if ActiveModel::VERSION::MAJOR >= 5
+        before_save { throw(:abort) unless !destroyed? && valid? }
+      else
+        before_save { !destroyed? && valid? }
+      end
     end
   end
 end


### PR DESCRIPTION
Hi @zacharywelch ,

while upgrading one of my rails-apis to Rails 5.0, I noticed that callbacks must be halted differently.

Returning `false` in a `before_*` callback will not halt the execution for Rails version >= 5.1 according to [this PR](https://github.com/rails/rails/pull/17227). You should `throw(:abort)` instead.

I added a conditional that checks for AM version. Let me know your thoughts :)
